### PR TITLE
Do not register the route until next is ready

### DIFF
--- a/api/src/initializers/next.ts
+++ b/api/src/initializers/next.ts
@@ -21,10 +21,6 @@ export class Next extends Initializer {
         return api.next.handle(req, res);
       },
     };
-
-    if (config.servers.web.enabled === true) {
-      route.registerRoute("get", "/", "next:render", null, true);
-    }
   }
 
   async start() {
@@ -50,6 +46,10 @@ export class Next extends Initializer {
 
     api.next.handle = api.next.app.getRequestHandler();
     await api.next.app.prepare();
+
+    if (config.servers.web.enabled === true) {
+      route.registerRoute("get", "/", "next:render", null, true);
+    }
   }
 
   async stop() {

--- a/api/src/initializers/next.ts
+++ b/api/src/initializers/next.ts
@@ -4,7 +4,9 @@ import next from "next";
 export class Next extends Initializer {
   constructor() {
     super();
-    this.loadPriority = 9999;
+    this.loadPriority = 1000;
+    this.startPriority = 899;
+    this.startPriority = 101;
     this.name = "next";
   }
 


### PR DESCRIPTION
* prevents clients from seeing an error page similar to `next is undefined`
* starts the next server just before the web server starts
* stops the next server just after the web server stops
* does not add the next "catch all" route until after the next server is running.  This also has the side effect of the next "catch all" route as being the last route, as it won't be injected until the `start` step of the lifecycle.  All other routes should be injected in the `initialize` part of the lifecycle